### PR TITLE
Fix writing version file keys

### DIFF
--- a/src/lein_git_version/plugin.clj
+++ b/src/lein_git_version/plugin.clj
@@ -18,7 +18,7 @@
     (io/make-parents f)
     (with-open [writer (io/writer f)]
       (binding [*out* writer]
-        (prn (select-keys project)))))
+        (prn (select-keys project keys)))))
 
   ;; Don't transform the project so as to fit in the cond-> pipeline
   project)


### PR DESCRIPTION
Fixes a select-keys incorrect arty bug.

```
clojure.lang.ArityException: Wrong number of args (1) passed to: core/select-keys
 at clojure.lang.AFn.throwArity (AFn.java:429)
    clojure.lang.AFn.invoke (AFn.java:32)
    lein_git_version.plugin$write_version_file$fn__581.invoke (plugin.clj:21)
```