### PR TITLE
Sanitize branch name in status-to-version example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ itself to compute its own version.
              tag
              (let [[_ prefix patch] (re-find #"(\d+\.\d+)\.(\d+)" tag)
                    patch            (Long/parseLong patch)
-                   patch+           (inc patch)]
-               (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch))))
+                   patch+           (inc patch)
+                   branch+          (-> branch
+                                       (.replaceAll "[^A-Za-z0-9]" "_"))]
+               (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch+))))
   }
   ...)
 ```


### PR DESCRIPTION
If someone has a branch named like e.g. "pull/100", the example `:status-to-version` function will fail to produce a jar. I imagine lots of people using this will just copy the example verbatim into their project.clj so hopefully this will prevent a few build failures.